### PR TITLE
Added Flask Quickstart guide

### DIFF
--- a/sqlite-cloud/_nav.ts
+++ b/sqlite-cloud/_nav.ts
@@ -11,8 +11,9 @@ const sidebarNav: SidebarNavStruct = [
 	{ title: "Quick Start Guides", type: "inner", level: 0 },
 	{ title: "Node.js", filePath: "quick-start-node", type: "inner", level: 1 },
 	{ title: "React", filePath: "quick-start-react", type: "inner", level: 1 },
-	// { title: "React Native", filePath: "sqlite-cloud/quick-start-react-native", type: "inner", level: 1 },
-	// { title: "Django", filePath: "quick-start-django", type: "inner", level: 1 },
+	{ title: "React Native", filePath: "sqlite-cloud/quick-start-react-native", type: "inner", level: 1 },
+	{ title: "Django", filePath: "quick-start-django", type: "inner", level: 1 },
+	{ title: "Flask", filePath: "quick-start-flask", type: "inner", level: 1 },
 
 	{ title: "Platform", type: "secondary", icon: "docs-plat" },
 	{ title: "Edge Functions", filePath: "edge-functions", type: "inner", level: 0 },

--- a/sqlite-cloud/quick-start-flask.mdx
+++ b/sqlite-cloud/quick-start-flask.mdx
@@ -1,0 +1,80 @@
+---
+title: Flask Quick Start Guide
+description: Get started with SQLite Cloud using Flask.
+category: getting-started
+status: publish
+slug: quick-start-flask
+---
+
+In this quickstart, we will show you how to get started with SQLite Cloud and Flask by building a simple application that connects to and reads from a SQLite Cloud database.
+
+---
+
+1. **Set up a SQLite Cloud account**
+  - If you haven't already, [sign up for a SQLite Cloud account](https://sqlitecloud.io/register) and create a new database.
+  - In this guide, we will use the sample datasets that come pre-loaded with SQLite Cloud.
+
+2. **Create a Flask app**
+  - You should have the latest Python version (3) installed locally.
+
+```bash
+mkdir sqlc-quickstart
+cd sqlc-quickstart
+
+python3 -m venv .venv
+. .venv/bin/activate
+
+pip install flask
+```
+
+3. **Install the SQLite Cloud SDK**
+
+```bash
+pip install sqlitecloud
+```
+
+4. **Query data**
+  - Copy the following code into a new `app.py` file.
+  - In your SQLite Cloud account dashboard, click your Project name, copy the Connection String, and replace `<your-connection-string>` below.
+
+```py
+from flask import Flask
+import sqlitecloud
+
+app = Flask(__name__)
+
+@app.route('/')
+def get_albums():
+    conn = sqlitecloud.connect('<your-connection-string>')
+
+    db_name = 'chinook.sqlite'
+    db_query = "SELECT albums.AlbumId as id, albums.Title as title, artists.name as artist FROM albums INNER JOIN artists WHERE artists.ArtistId = albums.ArtistId LIMIT 20"
+
+    conn.execute(f"USE DATABASE {db_name}")
+
+    cursor = conn.execute(db_query)
+
+    conn.close()
+
+    result = '<div><h1>Albums</h1>'
+
+    for row in cursor:
+        album = f"{row[1]} by {row[2]}"
+        result += f"<li>{album}</li>"
+
+    return result + '</div>'
+```
+
+5. **Run your app**
+  - If you're using port 5000 or on MacOS, also pass the `--port` option to provdie an open port.
+  - Pass the --debug option to enable hot reloading and interactive debugging on your dev server.
+
+```bash
+flask run --port 3000 --debug
+```
+
+6. **View your app**
+  - Open your browser and navigate to `http://127.0.0.1:3000/` to see your app data.
+  - If you're unfamiliar with Flask, the code above calls the `get_albums` function when you load the root URL. The function returns a string with HTML for the browser to render.
+
+And that's it! You've successfully built a Flask app that reads data from a SQLite Cloud database.


### PR DESCRIPTION
# Overview / Task
- [ ] Bug
- [x] Feature

## Description
- Created Python/ Flask project Quickstart guide.
- Added link in Documentation left nav for users to view Flask Quickstart.

## Feature Validation / Bug Reproduction Steps
1. From the `website` repo, `cd docs-website/content/docs` and `npm run dev-docs-website`.
2. Load the localhost link in browser: http://localhost:####/docs/quick-start-flask.

## Screenshots & Videos
<img width="1438" alt="Screenshot 2024-07-11 at 11 30 20 PM" src="https://github.com/user-attachments/assets/38da6778-6374-47c0-b346-b0a4836fd1d8">
<img width="721" alt="Screenshot 2024-07-11 at 11 30 53 PM" src="https://github.com/user-attachments/assets/fb250a27-9ff5-44eb-a892-ffe685a775d1">