### PR TITLE
Updated Django Quickstart guide

### DIFF
--- a/sqlite-cloud/_nav.ts
+++ b/sqlite-cloud/_nav.ts
@@ -11,8 +11,8 @@ const sidebarNav: SidebarNavStruct = [
 	{ title: "Quick Start Guides", type: "inner", level: 0 },
 	{ title: "Node.js", filePath: "quick-start-node", type: "inner", level: 1 },
 	{ title: "React", filePath: "quick-start-react", type: "inner", level: 1 },
-	// { title: "React Native", filePath: "sqlite-cloud/quick-start-react-native", type: "inner", level: 1 },
-	// { title: "Django", filePath: "quick-start-django", type: "inner", level: 1 },
+	{ title: "React Native", filePath: "sqlite-cloud/quick-start-react-native", type: "inner", level: 1 },
+	{ title: "Django", filePath: "quick-start-django", type: "inner", level: 1 },
 
 	{ title: "Platform", type: "secondary", icon: "docs-plat" },
 	{ title: "Edge Functions", filePath: "edge-functions", type: "inner", level: 0 },

--- a/sqlite-cloud/_nav.ts
+++ b/sqlite-cloud/_nav.ts
@@ -11,7 +11,7 @@ const sidebarNav: SidebarNavStruct = [
 	{ title: "Quick Start Guides", type: "inner", level: 0 },
 	{ title: "Node.js", filePath: "quick-start-node", type: "inner", level: 1 },
 	{ title: "React", filePath: "quick-start-react", type: "inner", level: 1 },
-	{ title: "React Native", filePath: "sqlite-cloud/quick-start-react-native", type: "inner", level: 1 },
+	{ title: "React Native", filePath: "quick-start-react-native", type: "inner", level: 1 },
 	{ title: "Django", filePath: "quick-start-django", type: "inner", level: 1 },
 
 	{ title: "Platform", type: "secondary", icon: "docs-plat" },

--- a/sqlite-cloud/quick-start-django.mdx
+++ b/sqlite-cloud/quick-start-django.mdx
@@ -6,72 +6,150 @@ status: publish
 slug: quick-start-django
 ---
 
-In this quickstart, we will show you how to get started with SQLite Cloud and Django by building a simple application that connects to and reads from a SQLite Cloud database, and returns the result to a lightweight client.
+In this quickstart, we will show you how to get started with SQLite Cloud and Django by building a simple application that connects to and reads from a SQLite Cloud database.
 
 1. **Set up a SQLite Cloud account**
   - If you haven't already, [sign up for a SQLite Cloud account](https://sqlitecloud.io/register) and create a new database.
   - In this guide, we will use the sample datasets that come pre-loaded with SQLite Cloud.
 
 2. **Create a Django app**
-  - Create a Django app using the following command:
+  - If you haven't already done so, [install Python and Django](https://docs.djangoproject.com/en/5.0/intro/install/).
+  - The following command creates an outer directory (the container for your project) AND an inner directory (the Python package for your project). Both directories will be named `sqlitecloud_quickstart`.
+
 ```bash
 django-admin startproject sqlitecloud_quickstart
 ```
-  - Create a new app within the project:
+  - The following command creates your app as a separate package within the project container directory.
+
 ```bash
 cd sqlitecloud_quickstart
-python manage.py startapp quickstart
+python manage.py startapp albums
 ```
 
-3. **Install the SQLite Cloud SDK**
+3. **Install the SQLite Cloud Python SDK**
+  - Run this command from your current directory (i.e. the outer `sqlitecloud_quickstart`).
+
 ```bash
 pip install sqlitecloud
 ```
 
-4. **Query data**
-  - Grab a connection string by clicking on a node in your dashboard.
-  - Create a file `services.py` within the quickstart directory. Use the following code to display data from your database.
+4. **App setup**
+  - Create a new file `albums/services.py` and copy in the following code.
+  - In your SQLite Cloud account dashboard, click your Project name, copy the Connection String, and replace `<your-connection-string>` below.
 
 ```python
 import sqlitecloud
 
-# Create your models here.
-db = sqlitecloud.connect('<your-connection-string>')
-
 def get_albums():
-  result = db.execute('''
-  USE DATABASE chinook.sqlite; 
-  SELECT albums.AlbumId as id, albums.Title as title, artists.name as artist
-  FROM albums 
-  INNER JOIN artists 
-  WHERE artists.ArtistId = albums.ArtistId
-  LIMIT 20;
-  ''')
-  return result.fetchall()
+  conn = sqlitecloud.connect('<your-connection-string>')
 
+  db_name = "chinook.sqlite"
+  db_query = "SELECT albums.AlbumId as id, albums.Title as title, artists.name as artist FROM albums INNER JOIN artists WHERE artists.ArtistId = albums.ArtistId LIMIT 20"
+
+  conn.execute(f"USE DATABASE {db_name}")
+
+  cursor = conn.execute(db_query)
+
+  conn.close()
+
+  result = cursor.fetchall()
+
+  return result
 ```
-  - Use the following code to display the data in a Django view:
+
+  - Copy the following code into `albums/views.py`. This view function invokes the `get_albums()` function defined in `services.py` to connect to the database and return album and artist information.
+  - The view function converts each returned row from a list to an object to more easily access the information in our HTML template (will discuss further later).
+
 ```python
-from django.http import JsonResponse
+from django.http import HttpResponse
+from django.template import loader
 from .services import get_albums
 
-def albums(request):
-    data = get_albums()
-    return JsonResponse(data, safe=False)
+def index(request):
+  albumsList = get_albums()
+
+  albumObjsList = [{'album': row[1], 'artist': row[2]} for row in albumsList]
+
+  template = loader.get_template("albums/index.html")
+  context = {
+      "albumObjsList": albumObjsList,
+  }
+  return HttpResponse(template.render(context, request))
 ```
-  - Add the following URL pattern to your project's `urls.py` file:
+
+  - Create a new file `albums/urls.py` and copy in the following code. This URL configuration (URLconf) maps the above view to a URL so we can access the view in the browser.
+
 ```python
 from django.urls import path
-from quickstart import albums
+from . import views
 
 urlpatterns = [
-    path('albums/', albums),
+    path("", views.index, name="index")
 ]
 ```
-  - Run the Django development server:
+
+  - Adjust the code in `sqlitecloud_quickstart/urls.py` to be as follows. We must configure this global URLconf in the inner `sqlitecloud_quickstart` to include the URLconf we defined above in our app.
+
+```python
+from django.contrib import admin
+from django.urls import include, path
+
+# global URLconfs
+urlpatterns = [
+    path("albums/", include("albums.urls")),
+    path('admin/', admin.site.urls),
+]
+```
+
+  - Now we'll create a Django template the view can use to render HTML. Under `albums`, create a new file at `templates/albums/index.html` and copy in the following code.
+    - Bear in mind, there are now 2 (outer and inner) `albums` directories.
+    - The `index` view function above is already set up to load and render the template `albums/index.html`. (NOTE: `albums` here is the inner `albums` dir.)
+
+```html
+<div>
+    <h1>Albums</h1>
+    <ul>
+    {% for row in albumObjsList %}
+        <li>{{ row.album }} by {{ row.artist }}</li>
+    {% endfor %}
+    </ul>
+</div>
+```
+  - Lastly, in `sqlitecloud_quickstart/settings.py`, configure `DIRS` in `TEMPLATES` as follows.
+    - `'APP_DIRS': True` tells Django's templating engine to look for template source files inside project apps.
+    - `DIRS` provides the filepath to the correct app's `templates` dir.
+
+```python
+TEMPLATES = [
+    {
+        'BACKEND': 'django.template.backends.django.DjangoTemplates',
+        'DIRS': ['albums/templates'],
+        'APP_DIRS': True,
+        'OPTIONS': {
+            'context_processors': [
+                'django.template.context_processors.debug',
+                'django.template.context_processors.request',
+                'django.contrib.auth.context_processors.auth',
+                'django.contrib.messages.context_processors.messages',
+            ],
+        },
+    },
+]
+```
+
+5. **Run the Django dev server**
+
 ```bash
 python manage.py runserver
 ```
-  - Visit `http://localhost:8000/albums/` to see the data returned from your SQLite Cloud database.
+
+  - Visit `http://127.0.0.1:8000/albums/` to see your app data.
+
+6. **FOLLOW-UP:**
+This Quickstart goes a bit deeper into the framework than the other Quickstarts since Django requires more boilerplate to get up-and-running with a simple app.
+
+If you're new to Django and want to learn more, we referenced the following Django Tutorial pages extensively when writing this Quickstart:
+  - [Part 1](https://docs.djangoproject.com/en/5.0/intro/tutorial01)
+  - [Part 3](https://docs.djangoproject.com/en/5.0/intro/tutorial03)
 
 And that's it! You've successfully built a Django app that reads data from a SQLite Cloud database.


### PR DESCRIPTION
# Overview / Task
- [x] Bug
- [x] Feature

## Description
**Quickstart doc changes:**
- Updated Python/ Django project Quickstart guide, since I couldn't get the app up-and-running using the currently live version.
- Added context to help devs new to Django understand what each code snippet does, and linked relevant Django docs for further clarification if needed.

**App changes:**
- I managed to get the current app up (after struggling with the Django docs for 50 mins) but it displayed raw album data. To align this app with the other Quickstart apps, I updated the view to load a simple Django HTML template with a heading and list of albums pulled from the DB.

## Feature Validation / Bug Reproduction Steps
1. From the `website` repo, `cd docs-website/content/docs` and `npm run dev-docs-website`.
2. Load the localhost link in browser: http://localhost:####/docs/quick-start-django.

## Screenshots & Videos
<img width="722" alt="Screenshot 2024-07-12 at 6 36 05 PM" src="https://github.com/user-attachments/assets/06d9fb46-b84b-455a-a32f-09f5915f4b4e">
<img width="724" alt="Screenshot 2024-07-12 at 6 36 26 PM" src="https://github.com/user-attachments/assets/8e4f5a01-ffe0-461b-8727-ba4540afc19e">