### PR TITLE
Added PHP / Laravel Quickstart guide

### DIFF
--- a/sqlite-cloud/_nav.ts
+++ b/sqlite-cloud/_nav.ts
@@ -12,10 +12,11 @@ const sidebarNav: SidebarNavStruct = [
 	{ title: "CDN", filePath: "quick-start-cdn", type: "inner", level: 1 },
 	{ title: "Node.js", filePath: "quick-start-node", type: "inner", level: 1 },
 	{ title: "React", filePath: "quick-start-react", type: "inner", level: 1 },
-	{ title: "Next.js", filePath: "quick-start-next", type: "inner", level: 1 },
 	{ title: "React Native", filePath: "quick-start-react-native", type: "inner", level: 1 },
+	{ title: "Next.js", filePath: "quick-start-next", type: "inner", level: 1 },
 	{ title: "Django", filePath: "quick-start-django", type: "inner", level: 1 },
-  	{ title: "Flask", filePath: "quick-start-flask", type: "inner", level: 1 },
+	{ title: "Flask", filePath: "quick-start-flask", type: "inner", level: 1 },
+	{ title: "PHP / Laravel", filePath: "quick-start-php-laravel", type: "inner", level: 1 },
 
 	{ title: "Platform", type: "secondary", icon: "docs-plat" },
 	{ title: "Edge Functions", filePath: "edge-functions", type: "inner", level: 0 },

--- a/sqlite-cloud/quick-start-cdn.mdx
+++ b/sqlite-cloud/quick-start-cdn.mdx
@@ -157,7 +157,7 @@ Copy the following to your ```index.html``` file:
 
 5. **Query data**
     - There are 2 ways to query data.
-        1. In your SQLite Cloud account dashboard, click your Project name, copy the Connection String, and paste it into the form's `Database Connection String` input. The expected string format is: `sqlitecloud://{host}.sqlite.cloud:8860?apikey={apikey}`.
+        1. In your SQLite Cloud account dashboard, click on a Node, copy the Connection String, and paste it into the form's `Database Connection String` input. The expected string format is: `sqlitecloud://{host}.sqlite.cloud:8860?apikey={apikey}`.
         
         - Since this Connection String format does NOT contain the database to query, you MUST include the database name in your query. The expected query format is: `USE DATABASE {database}; select * from {table}`.
             - IMPORTANT: The example SQL we provide (`USE DATABASE chinook.sqlite; select * from customers limit 3`) queries the `customers` table in the `chinook` database. The results are specifically parsed to be more readable. To display raw data from any table, uncomment the `index.html` code starting after `// list raw data` and comment out the later `for` loop.

--- a/sqlite-cloud/quick-start-django.mdx
+++ b/sqlite-cloud/quick-start-django.mdx
@@ -35,7 +35,7 @@ pip install sqlitecloud
 
 4. **App setup**
   - Create a new file `albums/services.py` and copy in the following code.
-  - In your SQLite Cloud account dashboard, click your Project name, copy the Connection String, and replace `<your-connection-string>` below.
+  - In your SQLite Cloud account dashboard, click on a Node, copy the Connection String, and replace `<your-connection-string>` below.
 
 ```python
 import sqlitecloud

--- a/sqlite-cloud/quick-start-flask.mdx
+++ b/sqlite-cloud/quick-start-flask.mdx
@@ -35,7 +35,7 @@ pip install sqlitecloud
 
 4. **Query data**
   - Copy the following code into a new `app.py` file.
-  - In your SQLite Cloud account dashboard, click your Project name, copy the Connection String, and replace `<your-connection-string>` below.
+  - In your SQLite Cloud account dashboard, click on a Node, copy the Connection String, and replace `<your-connection-string>` below.
 
 ```py
 from flask import Flask

--- a/sqlite-cloud/quick-start-php-laravel.mdx
+++ b/sqlite-cloud/quick-start-php-laravel.mdx
@@ -1,0 +1,147 @@
+---
+title: PHP / Laravel Quick Start Guide
+description: Get started with SQLite Cloud using PHP and Laravel.
+category: getting-started
+status: publish
+slug: quick-start-php-laravel
+---
+
+In this quickstart, we will show you how to get started with SQLite Cloud and PHP by building a simple Laravel application that connects to and reads from a SQLite Cloud database.
+
+---
+
+1. **Set up a SQLite Cloud account**
+  - If you haven't already, [sign up for a SQLite Cloud account](https://sqlitecloud.io/register) and create a new database.
+  - In this guide, we will use the sample datasets that come pre-loaded with SQLite Cloud.
+
+2. **Create a Laravel app**
+  - If you haven't already done so, install PHP, Laravel, and Composer.
+    - If you use macOS, you can install all 3 in 1 click by [downloading Laravel Herd](https://herd.laravel.com/docs/1/getting-started/installation#installation), a PHP dev environment.
+  - Create a new Laravel project.
+
+```bash
+composer create-project laravel/laravel sqlc-quickstart
+```
+
+  - In the project directory, start Laravel's local dev server.
+
+```bash
+cd sqlc-quickstart
+php artisan serve
+```
+
+  - Visit `http://127.0.0.1:8000` to see your Laravel app.
+
+3. **Configure a Blade frontend**
+  - Open another terminal. Again in your project dir, install Laravel Breeze.
+    - By default, Breeze uses simple Blade templates for your app's view layer. Blade is a templating engine included with Laravel. HTML is rendered server-side so you can include dynamic content from your database.
+
+```bash
+composer require laravel/breeze --dev
+php artisan breeze:install blade
+```
+
+  - Start a Vite dev server that will hot reload updates to your app. (No need to load the provided localhost link, just keep the Vite server running.)
+
+```bash
+npm run dev
+```
+
+  - Refresh your app in the browser. Click the "Register" link at the top right. Register an account and log in. Save your credentials.
+
+4. **App setup**
+
+  - Open another terminal. Again in your project dir, run `php artisan make:model -rc Album` to create an Eloquent Model (which we'll ignore) and a HTTP resource controller: `app/Http/Controllers/AlbumController.php`. We'll add functionality to this file to process app requests and return responses later.
+  - Replace the code in `routes/web.php` with the following snippet to add a route named `albums.index`.
+    - Run `php artisan route:list` to view all your app routes.
+    - `albums.index` will route GET requests to the `albums` endpoint to `AlbumController`'s `index` method (will set up later).
+
+```php
+<?php
+
+use App\Http\Controllers\AlbumController;
+use Illuminate\Support\Facades\Route;
+
+Route::resource('albums', AlbumController::class)
+    ->only(['index']);
+```
+
+  - Create a new file `resources/views/albums/index.blade.php` and copy in the following code to create your Blade view template.
+
+```php
+<h1>Albums</h1>
+<ul>
+@foreach ($albums as $album)
+    <li>{{ $album['albumTitle'] }} by {{ $album['artistName'] }}</li>
+@endforeach
+</ul>
+```
+
+5. **Install the SQLite Cloud SDK**
+
+```bash
+composer require sqlitecloud/sqlitecloud
+```
+
+6. **Query data**
+
+  - Replace the code in `app/Http/Controllers/AlbumController.php` with the following snippet.
+  - In your SQLite Cloud account dashboard, click on a Node, copy the Connection String, and replace `<your-connection-string>` below.
+  - The `index` method will:
+    - connect to and query the database,
+    - create an array of arrays `albums` containing each returned album's title and artist,
+    - use the global `view` helper to pass `albums` to your view template stored at `resources/views/albums/index.blade.php` (and already set up to list the data), and
+    - return the completed Blade view to the browser.
+
+```php
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\View\View;
+use SQLiteCloud\SQLiteCloudClient;
+use SQLiteCloud\SQLiteCloudRowset;
+
+class AlbumController extends Controller
+{
+    public function index(): View
+    {
+        $sqlite = new SQLiteCloudClient();
+        $sqlite->connectWithString('<your-connection-string>');
+
+        $db_name = 'chinook.sqlite';
+        $db_query = 'SELECT albums.AlbumId as id, albums.Title as title, artists.name as artist FROM albums INNER JOIN artists WHERE artists.ArtistId = albums.ArtistId LIMIT 20';
+
+        $sqlite->execute("USE DATABASE {$db_name}");
+        
+        $rowset = $sqlite->execute($db_query);
+
+        $sqlite->disconnect();
+
+        $albums = [];
+
+        for($i = 0; $i < $rowset->nrows; $i++) {
+            $albums[] = [
+                'albumTitle' => $rowset->value($i, 1),
+                'artistName' => $rowset->value($i, 2),
+            ];
+        }
+        
+        return view('albums.index', [ 
+            'albums' => $albums
+        ]);
+    }
+}
+```
+
+7. **View your app**
+  - Visit `http://127.0.0.1:8000/albums` to see your app data.
+
+8. **FOLLOW-UP:**
+This Quickstart goes a bit deeper into the framework than the other Quickstarts since Laravel requires more boilerplate to get up-and-running with a simple app.
+
+If you're new to Laravel and want to learn more, we referenced the following Laravel Tutorial pages extensively when writing this Quickstart:
+  - [Installation](https://bootcamp.laravel.com/blade/installation)
+  - [Controllers, Routing, Blade](https://bootcamp.laravel.com/blade/creating-chirps)
+
+And that's it! You've successfully built a PHP / Laravel app that reads data from a SQLite Cloud database.


### PR DESCRIPTION
# Overview / Task
- [ ] Bug
- [x] Feature

## Description
- Created PHP / Laravel project Quickstart guide.
- Added link in Documentation left nav for users to view PHP / Laravel Quickstart.
- Corrected multiple Quickstarts: users don't click on their Project name (top left icon) to get their connection string in the updated dashboard view. They can get the string by selecting any Node.

## Feature Validation / Bug Reproduction Steps
1. From the `website` repo, `cd docs-website/content/docs` and `npm run dev-docs-website`.
2. Load the localhost link in browser: http://localhost:####/docs/quick-start-php-laravel.

## Screenshots & Videos
<img width="722" alt="Screenshot 2024-07-16 at 5 34 00 PM" src="https://github.com/user-attachments/assets/56befa96-b807-4294-a207-48c0a130a406">
<img width="721" alt="Screenshot 2024-07-16 at 5 33 41 PM" src="https://github.com/user-attachments/assets/a4b66510-8056-483b-8ae3-4cf916e11c6b">