### PR TITLE
Added Streamlit Quick Start guide

### DIFF
--- a/sqlite-cloud/_nav.ts
+++ b/sqlite-cloud/_nav.ts
@@ -16,6 +16,7 @@ const sidebarNav: SidebarNavStruct = [
 	{ title: "React Native", filePath: "quick-start-react-native", type: "inner", level: 1 },
 	{ title: "Django", filePath: "quick-start-django", type: "inner", level: 1 },
   	{ title: "Flask", filePath: "quick-start-flask", type: "inner", level: 1 },
+	{ title: "Streamlit", filePath: "quick-start-streamlit", type: "inner", level: 1 },
 
 	{ title: "Platform", type: "secondary", icon: "docs-plat" },
 	{ title: "Edge Functions", filePath: "edge-functions", type: "inner", level: 0 },

--- a/sqlite-cloud/quick-start-streamlit.mdx
+++ b/sqlite-cloud/quick-start-streamlit.mdx
@@ -27,7 +27,7 @@ python3 -m venv .venv
 pip install streamlit
 ```
 
-1. **Install the SQLite Cloud SDK**
+3. **Install the SQLite Cloud SDK**
 
 ```bash
 pip install sqlitecloud
@@ -60,7 +60,7 @@ st.dataframe(invoices, hide_index=True)
 streamlit run app.py
 ```
 
-1. **View your app**
+6. **View your app**
   - Open your browser and navigate to the localhost link provided by the previous command to see your app data.
 
 And that's it! You've successfully built a Streamlit app that reads data from a SQLite Cloud database.

--- a/sqlite-cloud/quick-start-streamlit.mdx
+++ b/sqlite-cloud/quick-start-streamlit.mdx
@@ -1,0 +1,66 @@
+---
+title: Streamlit Quick Start Guide
+description: Get started with SQLite Cloud using Streamlit.
+category: getting-started
+status: publish
+slug: quick-start-streamlit
+---
+
+In this quickstart, we will show you how to get started with SQLite Cloud and Streamlit by building a simple application that connects to and reads from a SQLite Cloud database.
+
+---
+
+1. **Set up a SQLite Cloud account**
+  - If you haven't already, [sign up for a SQLite Cloud account](https://sqlitecloud.io/register) and create a new database.
+  - In this guide, we will use the sample datasets that come pre-loaded with SQLite Cloud.
+
+2. **Create a Streamlit app**
+  - You should have the latest Python version (3) installed locally.
+
+```bash
+mkdir sqlc-quickstart
+cd sqlc-quickstart
+
+python3 -m venv .venv
+. .venv/bin/activate
+
+pip install streamlit
+```
+
+1. **Install the SQLite Cloud SDK**
+
+```bash
+pip install sqlitecloud
+```
+
+4. **Query data**
+  - Copy the following code into a new `app.py` file.
+  - In your SQLite Cloud account dashboard, click your Project name, copy the Connection String, and replace `<your-connection-string>` below.
+
+```py
+import streamlit as st
+import sqlitecloud
+import pandas as pd
+
+st.header('Invoices')
+
+conn = sqlitecloud.connect('<your-connection-string>')
+
+db_name = "chinook.sqlite"
+conn.execute(f"USE DATABASE {db_name}")
+
+invoices = pd.read_sql("SELECT * FROM invoices LIMIT 20", conn)
+
+st.dataframe(invoices, hide_index=True)
+```
+
+5. **Run your app**
+
+```bash
+streamlit run app.py
+```
+
+1. **View your app**
+  - Open your browser and navigate to the localhost link provided by the previous command to see your app data.
+
+And that's it! You've successfully built a Streamlit app that reads data from a SQLite Cloud database.


### PR DESCRIPTION
## Overview/Task

- [ ] Bug
- [x] Feature

### Description
- Created Python/Streamlit project Quick Start guide.
- Added link to Documentation on left nav bar.

### Feature Validation/Bug Reproduction Steps
1. From the `website` repo, `cd docs-website/content/docs` and `npm run dev-docs-website`.
2. Load the localhost link in the browser.

### Screenshots & Videos
<img width="1722" alt="streamlit_quick_start_docs" src="https://github.com/user-attachments/assets/7a4f4d39-9c19-460c-8376-40576586abaf">

<img width="1714" alt="invoices_dashboard" src="https://github.com/user-attachments/assets/b45e398b-7e1c-4c71-a9f9-d2e737de8203">

### Additional notes
For the Quick Start guide I used pandas to query the chinook.sqlite database. Everything works well but the user does get the following warning in the terminal. 
![Screenshot 2024-07-18 at 1 24 00 PM](https://github.com/user-attachments/assets/03be2278-4199-4144-926f-49dedd8960df)

I did write an example that doesn't use pandas. If you'd prefer me to use the code below or make any edits please let me know.
```py
import streamlit as st
import sqlitecloud

st.header('Invoices')

conn = sqlitecloud.connect('<your-connection-string>')

db_name = "chinook.sqlite"
conn.execute(f"USE DATABASE {db_name}")

cursor = conn.execute("SELECT * FROM invoices LIMIT 20")
invoices = cursor.fetchall()

conn.close()

invoices_w_header = {
    "Invoice Id": [invoice[0] for invoice in invoices],
    "Customer Id": [invoice[1] for invoice in invoices],
    "Invoice Date": [invoice[2] for invoice in invoices],
    "Billing Address": [invoice[3] for invoice in invoices],
    "Billing City": [invoice[4] for invoice in invoices],
    "Billing State": [invoice[5] for invoice in invoices],
    "Billing Country": [invoice[6] for invoice in invoices],
    "Billing Postal Code": [invoice[7] for invoice in invoices],
    "Total": [invoice[8] for invoice in invoices]
}

st.dataframe(invoices_w_header, hide_index=True)

```