### PR TITLE
Fixed typo in Node.js Quick Start guide

### DIFF
--- a/sqlite-cloud/quick-start-node.mdx
+++ b/sqlite-cloud/quick-start-node.mdx
@@ -52,7 +52,7 @@ app.listen(3000, () => {
 ```
 5. **Run your app**
 ```bash
-node app.js
+node index.js
 ```
 6. **View your web server response**
    - Open your browser and navigate to `http://localhost:3000/albums` to see your app in action.


### PR DESCRIPTION
There was a typo in step 5. Run your app. It said to run the command `node app.js` but the command should be `node index.js`. The file we create to connect to the database is called `index.js`.