### PR TITLE
Added clarifications to PHP Intro

### DIFF
--- a/sqlite-cloud/quick-start-php-laravel.mdx
+++ b/sqlite-cloud/quick-start-php-laravel.mdx
@@ -86,7 +86,7 @@ composer require sqlitecloud/sqlitecloud
 6. **Query data**
 
   - Replace the code in `app/Http/Controllers/AlbumController.php` with the following snippet.
-  - In your SQLite Cloud account dashboard, click on a Node, copy the Connection String, and replace `<your-connection-string>` below.
+  - In your SQLite Cloud account dashboard, click on `Show connection strings`, copy the Connection String, and replace `<your-connection-string>` below.
   - The `index` method will:
     - connect to and query the database,
     - create an array of arrays `albums` containing each returned album's title and artist,

--- a/sqlite-cloud/sdks/php/introduction.mdx
+++ b/sqlite-cloud/sdks/php/introduction.mdx
@@ -6,22 +6,35 @@ status: publish
 slug: sdk-php-introduction
 ---
 
-
-[![Test and QA][test-qa-img]][test-qa-url]
-[![codecov][codecov-img]][codecov-url]
-[![Packagist Version][packagist-version-img]][packagist-url]
-[![PHP][php-img]][packagist-url]
+This powerful package provides methods that simplify performing database operations in PHP applications, making it easier than ever to work with SQLite in the cloud. We encourage all users to log encountered issues in the [SDK’s issues backlog](https://github.com/sqlitecloud/sqlitecloud-php/issues).
 
 ## Install
+
+  - Run the following command to initialize a PHP project and install the SDK.
 
 ```bash
 $ composer require sqlitecloud/sqlitecloud
 ```
 
-SQLite Cloud is a powerful PHP package that allows you to interact with the SQLite Cloud database seamlessly. It provides methods for various database operations. 
-This package is designed to simplify database operations in PHP applications, making it easier than ever to work with SQLite Cloud.
+## Configure your database connection
 
-## Example
+  - In your SQLite Cloud account dashboard, click on `Show connection strings`, copy the Connection String, and replace `<your-connection-string>` below.
+
+```php
+$sqlite->connectWithString("<your-connection-string>");
+```
+
+  - You can modify the connection string to include the name of the database to query.
+    - Here, the provided port (`8860`) and database (`chinook.sqlite`) will query the sample dataset that comes pre-loaded with SQLite Cloud. Replace to query your own datasets.
+
+```php
+$sqlite->connectWithString('sqlitecloud://{hostname}:8860/chinook.sqlite?apikey={apikey}');
+```
+
+## Connect and query
+
+  - Include the following snippet in a new `example.php` file.
+  - NOTE: `$sqlite->execute("USE DATABASE {$db_name}");` is only necessary if your connection string does NOT specify the name of the database to query.
 
 ```php
 <?php
@@ -31,18 +44,13 @@ require_once 'vendor/autoload.php';
 use SQLiteCloud\SQLiteCloudClient;
 use SQLiteCloud\SQLiteCloudRowset;
 
-// Open the connection to SQLite Cloud
 $sqlite = new SQLiteCloudClient();
-$sqlite->connectWithString('sqlitecloud://myhost.sqlite.cloud:8860?apikey=myapikey');
+$sqlite->connectWithString("<your-connection-string>");
 
-// You can autoselect the database during the connect call
-// by adding the database name as path of the SQLite Cloud
-// connection string, eg:
-// $sqlite->connectWithString("sqlitecloud://myhost.sqlite.cloud:8860/mydatabase?apikey=myapikey");
 $db_name = 'chinook.sqlite';
 $sqlite->execute("USE DATABASE {$db_name}");
 
- /** @var SQLiteCloudRowset */
+/** @var SQLiteCloudRowset */
 $rowset = $sqlite->execute('SELECT * FROM albums WHERE ArtistId = 2');
 
 printf('%d rows' . PHP_EOL, $rowset->nrows);
@@ -54,18 +62,35 @@ for ($i = 0; $i < $rowset->nrows; $i++) {
 $sqlite->disconnect();
 ```
 
-## PHP Admin
-To better understand the PHP APIs usage we developed a simple PHP Admin interface that can be used to administer any SQLite Cloud node.
+  - Run your app! 
+  
+```
+php example.php
+```
 
-You can login using admin credentials:
+## PHP Admin Dashboard
+
+You can use SQLite Cloud's simplified PHP Admin interface to administer any node.
+
+  - Clone the PHP SDK, install lock file dependencies, and run the dashboard locally.
+
+```bash
+git clone https://github.com/sqlitecloud/sqlitecloud-php.git
+
+composer update # or composer install
+cd admin
+php -S localhost:8000
+```
+
+  - Login as your admin user.
+    - In your SQLite Cloud account dashboard, click on `Show connection strings`, copy the Deployment string, and paste in `Hostname`.
+    - In your dashboard left nav, select Settings, then Users. Copy your admin user's username and paste in `Username`.
+    - In your User's row, click the down chevron, then Edit. Enter a Password and Save. Paste in `Password`.
+
 ![PHP Admin Login](@docs-website-assets/php/admin_login.png)
 
-And then administer your node with a convenient user interface:
 ![PHP Admin Overview](@docs-website-assets/php/admin_overview.png)
 
-PHP Admin source code is available in a [GitHub repo](https://github.com/sqlitecloud/sqlitecloud-php/tree/main/admin).
-
-## More
 [test-qa-img]: https://github.com/sqlitecloud/sqlitecloud-php/actions/workflows/deploy.yaml/badge.svg?branch=main
 [test-qa-url]: https://github.com/sqlitecloud/sqlitecloud-php/actions/workflows/deploy.yaml
 [codecov-img]: https://codecov.io/gh/sqlitecloud/sqlitecloud-php/graph/badge.svg?token=3FFHULGCOY

--- a/sqlite-cloud/sdks/swift/introduction.mdx
+++ b/sqlite-cloud/sdks/swift/introduction.mdx
@@ -27,24 +27,30 @@ let package = Package(
 
 1. **RECOMMENDED**: Use the `apikey` connection string.
 
-In your SQLite Cloud account dashboard, click on `Show connection strings`, copy the Connection String, and replace `<your-connection-string>` below.
+  - In your SQLite Cloud account dashboard, click on `Show connection strings`, copy the Connection String, and replace `<your-connection-string>` below.
 
 ```swift
 let configuration = SQLiteCloudConfig(connectionString: "<your-connection-string>")
 ```
 
+  - You can modify the connection string to include the name of the database to query.
+
+```swift
+let configuration = SQLiteCloudConfig(connectionString: "sqlitecloud://{hostname}:8860/{database}?apikey={apikey}")
+``` 
+
 2. Use a parameterized connection string.
 
-    - In your SQLite Cloud account dashboard, click on a Node, copy the Deployment string, and replace `{hostname}` below.
+    - In your SQLite Cloud account dashboard, click on `Show connection strings`, copy the Deployment string, and replace `{hostname}` below.
     - In your dashboard left nav, select Settings, then Users. Copy your username and replace `{username}`.
     - In your User's row, click the down chevron, then Edit. Enter a Password and Save. Replace `{password}`.
-    - The provided port and database will query the sample dataset that comes pre-loaded with SQLite Cloud. Replace both for your own datasets.
+    - Here, the provided port (`8860`) and database (`chinook.sqlite`) will query the sample dataset that comes pre-loaded with SQLite Cloud. Replace to query your own datasets.
 
 ```swift
 let configuration = SQLiteCloudConfig(connectionString: "sqlitecloud://{username}:{password}@{hostname}:8860/chinook.sqlite")
 ```
     
-3. Pass each connection string parameter.
+3. Pass each connection string parameter explicitly.
 
 ```swift
 let configuration = SQLiteCloudConfig(hostname: {hostname}, username: {username}, password: {password}, port: .default)
@@ -53,6 +59,7 @@ let configuration = SQLiteCloudConfig(hostname: {hostname}, username: {username}
 ## Connect and query
 
   - The following snippet includes variable types, which may be optional for your app.
+  - NOTE: `USE DATABASE chinook.sqlite;` is only necessary in the query if your `configuration` does not specify the name of the database to query.
   - Once you've incorporated the following, build and run your app!
 
 ```swift


### PR DESCRIPTION
# Overview / Task
- [x] Bug
- [x] Feature

## Description
- Added specific instructions on how to use the PHP SDK to do a basic query and print the results, as well as how to get up-and-running with the PHP Admin Dashboard.
- Found a bug in `admin/common.php`, logged in a separate [PR](https://github.com/sqlitecloud/sqlitecloud-php/pull/8). This bug was breaking the Dashboard UI.

## Feature Validation / Bug Reproduction Steps
1. From the `website` repo, `npm run dev-docs-website`.
2. Load the localhost link in browser: `http://localhost:4321/docs/sdk-php-introduction`.
3. Follow the instructions to load the Admin Dashboard and login to your account to administer node(s).

## Screenshots & Videos
<img width="1439" alt="Screenshot 2024-07-30 at 3 48 00 PM" src="https://github.com/user-attachments/assets/2b7d6c5f-cd58-468f-8d8f-03eab1724911">