### PR TITLE
Tutorial for Geopoly extension demo app

### DIFF
--- a/sqlite-cloud/_nav.ts
+++ b/sqlite-cloud/_nav.ts
@@ -20,6 +20,8 @@ const sidebarNav: SidebarNavStruct = [
 	{ title: "Streamlit", filePath: "quick-start-streamlit", type: "inner", level: 1 },
 	{ title: "PHP / Laravel", filePath: "quick-start-php-laravel", type: "inner", level: 1 },
 	{ title: "Gin", filePath: "quick-start-gin", type: "inner", level: 1 },
+	{ title: "Tutorials", type: "inner", level: 0 },
+	{ title: "SQLite Spotlight: Geopoly Extension", filePath: "tutorial-geopoly", type: "inner", level: 1 },
 
 	{ title: "Platform", type: "secondary", icon: "docs-plat" },
 	{ title: "Edge Functions", filePath: "edge-functions", type: "inner", level: 0 },
@@ -140,6 +142,8 @@ const sidebarNav: SidebarNavStruct = [
 	{ title: "React", ref: "/docs/quick-start-react", type: "inner", level: 2 },
 	{ title: "Node.js", ref: "/docs/quick-start-node", type: "inner", level: 2 },
 	{ title: "Next.js", ref: "/docs/quick-start-next", type: "inner", level: 2 },
+	{ title: "Tutorials", type: "inner", level: 1 },
+	{ title: "SQLite Spotlight: Geopoly Extension", ref: "/docs/tutorial-geopoly", type: "inner", level: 2 },
 	{ title: "Classes", type: "inner", level: 1 },
 	{ title: "Database", filePath: 'sqlite-cloud/sdks/js/classes/Database', type: "inner", level: 2 },
 	{ title: "SQLiteCloudConnection", filePath: 'sqlite-cloud/sdks/js/classes/SQLiteCloudConnection', type: "inner", level: 2 },

--- a/sqlite-cloud/_nav.ts
+++ b/sqlite-cloud/_nav.ts
@@ -21,7 +21,7 @@ const sidebarNav: SidebarNavStruct = [
 	{ title: "PHP / Laravel", filePath: "quick-start-php-laravel", type: "inner", level: 1 },
 	{ title: "Gin", filePath: "quick-start-gin", type: "inner", level: 1 },
 	{ title: "Tutorials", type: "inner", level: 0 },
-	{ title: "SQLite Spotlight: Geopoly Extension", filePath: "tutorial-geopoly", type: "inner", level: 1 },
+	{ title: "Using SQLite Extensions - Geopoly", filePath: "tutorial-geopoly", type: "inner", level: 1 },
 
 	{ title: "Platform", type: "secondary", icon: "docs-plat" },
 	{ title: "Edge Functions", filePath: "edge-functions", type: "inner", level: 0 },
@@ -143,7 +143,7 @@ const sidebarNav: SidebarNavStruct = [
 	{ title: "Node.js", ref: "/docs/quick-start-node", type: "inner", level: 2 },
 	{ title: "Next.js", ref: "/docs/quick-start-next", type: "inner", level: 2 },
 	{ title: "Tutorials", type: "inner", level: 1 },
-	{ title: "SQLite Spotlight: Geopoly Extension", ref: "/docs/tutorial-geopoly", type: "inner", level: 2 },
+	{ title: "Using SQLite Extensions - Geopoly", ref: "/docs/tutorial-geopoly", type: "inner", level: 2 },
 	{ title: "Classes", type: "inner", level: 1 },
 	{ title: "Database", filePath: 'sqlite-cloud/sdks/js/classes/Database', type: "inner", level: 2 },
 	{ title: "SQLiteCloudConnection", filePath: 'sqlite-cloud/sdks/js/classes/SQLiteCloudConnection', type: "inner", level: 2 },

--- a/sqlite-cloud/tutorial-geopoly.mdx
+++ b/sqlite-cloud/tutorial-geopoly.mdx
@@ -1,0 +1,801 @@
+---
+title: SQLite Spotlight - Geopoly Extension
+description: Build a local attractions finder app using SQLite Cloud, SQLite's built-in Geopoly extension, Mapbox, and React.
+category: getting-started
+status: publish
+slug: tutorial-geopoly
+---
+
+This tutorial demonstrates how to build a local attractions finder app. The app uses:
+- GeoJSON data
+- a SQLite Cloud database
+- Mapbox JavaScript Graphics Library (GL JS)
+  - user has to create an account/ get a token!
+- React
+- SQLite's built-in Geopoly extension
+
+Time to complete: ~15-20 mins.
+
+If you get stuck in the tutorial or prefer to play with the finished product, check out [the example app on GitHub](https://github.com/sqlitecloud/examples/tree/main/geopoly).
+
+---
+
+1. **Initialize your app**
+  - Create a new directory `sqlc-geopoly-demo`. From this directory, bootstrap a Node.js project.
+
+```bash
+mkdir sqlc-geopoly-demo
+cd sqlc-geopoly-demo
+npm init -y
+```
+
+2. **Curate your GeoJSON data**
+
+  - We will leverage the [Overpass API](https://wiki.openstreetmap.org/wiki/Overpass_API) (an open-source, read-only API for fetching OpenStreetMap data) to query NYC attractions.
+
+  - Visit [Overpass Turbo](https://overpass-turbo.eu/), the Overpass GUI. Copy and paste in the below query which:
+    - defines New York as the area of interest;
+    - fetches nodes in the specified area that are tagged with the keys `amenity`, `historic`, `tourism`, `leisure`, etc.; and
+    - outputs the data.
+
+```c
+[out:json][timeout:25];
+
+area[name="New York"]->.newyork;
+
+(
+  node["amenity"="events_venue"](area.newyork);
+  node["amenity"="exhibition_centre"](area.newyork);
+  node["amenity"="music_venue"](area.newyork);
+  node["amenity"="social_centre"](area.newyork);
+  node["amenity"="marketplace"](area.newyork);
+  node["building"="museum"](area.newyork);
+  node["historic"="building"](area.newyork);
+  node["tourism"="attraction"](area.newyork);
+  node["leisure"="park"](area.newyork);
+  node["natural"="beach"](area.newyork);
+  node["shop"="coffee"](area.newyork);
+  node["sport"="yoga"](area.newyork);
+);
+
+out body;
+>;
+out skel qt;
+```
+
+  - Run the query.
+
+  - Click Export. Under Data, copy the GeoJSON.
+
+  - Use [a JSON formatter](https://jsonformatter.org/) to correctly format the copied JSON.
+
+  - Back in your project dir, create `data/geodata.json`. Paste the formatted GeoJSON into the file. It should look as follows:
+
+```json
+{
+  "type": "FeatureCollection",
+  "generator": "overpass-turbo",
+  "copyright": "The data included in this document is from www.openstreetmap.org. The data is made available under ODbL.",
+  "timestamp": "2024-08-05T23:56:57Z",
+  "features": [
+    {
+      "type": "Feature",
+      "properties": {
+        "@id": "node/43058007",
+        "ele": "190",
+        "gnis:feature_id": "968527",
+        "leisure": "park",
+        "name": "Kibler Park"
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [-78.6723302, 43.1655945]
+      },
+      "id": "node/43058007"
+    },
+    ...,
+    {
+      "type": "Feature",
+      "properties": {
+        "@id": "node/12093603396",
+        "amenity": "events_venue",
+        "name": "Azteca Venue Party Center"
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [-74.1244477, 40.6338683]
+      },
+      "id": "node/12093603396"
+    }
+  ]
+}
+```
+
+  - To pull other types of attractions or any other kind of location data in an area of interest to you, refer to [OpenStreetMap's Map features documentation](https://wiki.openstreetmap.org/wiki/Map_features) and modify the above query's area and key-value pairs.
+
+  - NOTE: The app currently only works with Point features (represented in the [doc's](https://wiki.openstreetmap.org/wiki/Map_features) Element column by an icon containing a dot), so be sure to query only:
+    - nodes, and
+    - the key-value pairs that can return Point data. For example, don't use most values available for the Boundary key.
+
+  - To implement more complex or granular Point queries, refer to the [Overpass QL documentation](https://wiki.openstreetmap.org/wiki/Overpass_API/Overpass_QL).
+
+3. **Create a new / empty SQLite Cloud database**
+
+  - If you haven't already, [sign up for a SQLite Cloud account](https://sqlitecloud.io/register) and create a new project.
+
+  - In your account dashboard's left nav, click Databases, then the Create Database button. To minimize code changes, name your new database `geopoly-demo`.
+
+4. **Set an environment variable**
+
+  - In your project dir, create a `.env` file with a new environment variable `REACT_APP_CONNECTION_STRING`. Copy your connection string from your account dashboard and assign it to the variable.
+    - CONTEXT: This app will use `react-scripts`, which leverages Create React App under-the-hood. Create React App offers built-in support for env vars. You will not need to manually configure `webpack` or another bundler, but all vars must be prefixed with `REACT_APP_`.
+
+  - Install the SQLite Cloud JS SDK and dotenv package as dependencies:
+
+```bash
+npm i @sqlitecloud/drivers
+npm i -D dotenv
+```
+
+5. **Create your DB tables**
+
+  - In your project dir, create `src/helpers/createDatabase.js`. Copy and paste in the following code:
+
+```js
+import { Database } from '@sqlitecloud/drivers';
+import 'dotenv/config';
+import geodata from '../../data/geodata.json' assert { type: 'json' };
+
+async function createDatabase() {
+  const db = new Database(process.env.REACT_APP_CONNECTION_STRING);
+
+  const db_name = 'geopoly-demo';
+  await db.sql`USE DATABASE ${db_name};`;
+
+  await db.sql`CREATE VIRTUAL TABLE polygons USING geopoly()`;
+
+  await db.sql`CREATE TABLE attractions (id INTEGER PRIMARY KEY AUTOINCREMENT, name TEXT, lng REAL NOT NULL, lat REAL NOT NULL, coordinates TEXT NOT NULL)`;
+
+  for (const feature of geodata['features']) {
+    const { name } = feature.properties;
+    const { coordinates } = feature.geometry;
+    const [lng, lat] = coordinates;
+
+    await db.sql`INSERT INTO attractions(name, lng, lat, coordinates) VALUES(${name}, ${lng}, ${lat}, ${JSON.stringify(
+      coordinates
+    )})`;
+  }
+
+  db.close();
+
+  console.log('Geodata inserted!');
+}
+
+createDatabase();
+```
+
+  - The `createDatabase` function:
+    - connects to your `geopoly-demo` database
+    - creates a virtual Geopoly table with 2 columns: `rowid` (which does not display in SQLite Cloud's Console but can be queried) and `_shape`
+    - creates an `attractions` table with 5 columns: `id`, `name`, `lng`, `lat`, and `coordinates`
+    - populates the `attractions` table using the GeoJSON FeatureCollection you generated earlier
+    - closes the database connection.
+  
+  - Add the following script to your `package.json`:
+
+```json
+"scripts": {
+  "create-tables": "node src/helpers/createDatabase.js"
+}
+```
+
+  - Run `npm run create-tables`.
+
+    - The time it will take for the command to finish creating tables and inserting the geodata will depend on the size of your FeatureCollection. The example Overpass query provided above returns ~2000 NYC Point features and takes a couple of minutes.
+
+    - As an aside: To see the inserted attractions geodata, in your SQLite Cloud account dashboard's left nav, click Console. Copy, paste in, and run the following query:
+
+```sql
+SELECT * FROM attractions ORDER BY id DESC;
+```
+      - If you used the provided Overpass query, ~2000 rows are added.
+
+6. **Setup the frontend**
+
+  - In your project dir, create `public/index.html`. Copy and paste in the following code:
+
+```html
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta
+      name="description"
+      content="Create a React web app that uses Mapbox GL JS to render a map"
+    />
+    <title>Local Attraction Finder</title>
+  </head>
+  <body>
+    <noscript>You need to enable JavaScript to run this app.</noscript>
+    <div id="root"></div>
+  </body>
+</html>
+```
+
+  - In the `src` dir, add 3 files: `index.css` (for app styling), `index.js` (the app entrypoint file), and `App.js` (the one-and-only component). Copy and paste in the following code for each file:
+
+`index.css`
+```css
+@import url('https://fonts.googleapis.com/css2?family=Inter+Tight:wght@100..900&display=swap');
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  padding: 0;
+  font: 400 15px/22px 'Inter Tight', sans-serif;
+  -webkit-font-smoothing: antialiased;
+}
+
+.legend {
+  padding: 10px;
+  background-color: #23374b;
+  color: #fff;
+  font-family: monospace;
+}
+
+.sidebar {
+  position: absolute;
+  width: 25%;
+  height: 100%;
+  overflow: hidden;
+}
+
+.map-container {
+  position: absolute;
+  left: 25%;
+  width: 75%;
+  top: 0;
+  bottom: 0;
+}
+
+.heading {
+  padding: 0 10px;
+  border-bottom: 1px solid #eee;
+}
+
+.listings {
+  height: 72%;
+  overflow: auto;
+  padding-bottom: 15px;
+}
+
+.listings .item {
+  padding: 10px;
+  border-bottom: 1px solid #eee;
+}
+
+.listings .item.active {
+  background-color: #cfe1f8;
+}
+
+.listings .item:last-child {
+  border-bottom: none;
+}
+
+.listings .item .title {
+  color: #5a5877;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+.listings .item.active .title,
+.listings .item .title:hover {
+  color: #000;
+}
+
+::-webkit-scrollbar {
+  width: 5px;
+}
+
+::-webkit-scrollbar-track {
+  background: none;
+}
+
+::-webkit-scrollbar-thumb {
+  background: #23374b;
+}
+
+.mapboxgl-popup {
+  padding-bottom: 20px;
+}
+
+.mapboxgl-popup-close-button {
+  display: none;
+}
+
+.mapboxgl-popup-content {
+  padding: 0;
+}
+
+.mapboxgl-popup-content h3 {
+  background: #cfe1f8;
+  color: #000;
+  margin: 0;
+  padding: 10px;
+  border-radius: 3px 3px 0 0;
+  font-weight: 700;
+  margin-top: -15px;
+}
+
+.mapboxgl-popup-content h4 {
+  margin: 0;
+  padding: 10px;
+  font-weight: 400;
+}
+
+.marker {
+  border: none;
+  cursor: pointer;
+  width: 26px;
+  height: 34px;
+  background-image: url('https://docs.mapbox.com/mapbox-gl-js/assets/custom_marker.png');
+}
+
+.mapboxgl-ctrl-geocoder {
+  border: 0;
+  border-radius: 0;
+  position: relative;
+  top: 0;
+  width: 800px;
+  margin-top: 0;
+}
+
+.mapboxgl-ctrl-geocoder > div {
+  min-width: 100%;
+  margin-left: 0;
+}
+```
+
+  - NOTE: To simplify this tutorial, `.marker.background-image` uses a custom Mapbox marker for the map pins marking attractions. [The example app on GitHub](https://github.com/sqlitecloud/examples/tree/main/geopoly) uses a custom marker image included in the repo's `images` dir (excluded here).
+
+`index.js`
+```js
+import React from 'react';
+import { createRoot } from 'react-dom/client';
+import 'mapbox-gl/dist/mapbox-gl.css';
+import './index.css';
+import App from './App.js';
+
+const container = document.querySelector('#root');
+const root = createRoot(container);
+root.render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+);
+```
+
+`App.js`
+```js
+import { useState, useEffect, useRef } from 'react';
+import mapboxgl from 'mapbox-gl';
+import '@mapbox/mapbox-gl-geocoder/dist/mapbox-gl-geocoder.css';
+import MapboxGeocoder from '@mapbox/mapbox-gl-geocoder';
+import { point, distance } from '@turf/turf';
+import { Database } from '@sqlitecloud/drivers';
+import { getBbox } from './helpers/getBbox.js';
+
+mapboxgl.accessToken =
+  'pk.eyJ1IjoidW5hdGFyYWphbiIsImEiOiJjbDFpcW82MGYxeDE1M2RwNjU4MmZ1YndsIn0.HyxwEtZz-pQ_7R6e48l0-g';
+
+function App() {
+  const mapContainerRef = useRef();
+  const mapRef = useRef();
+
+  const [lng, setLng] = useState(-73.9654897);
+  const [lat, setLat] = useState(40.7824635);
+  const [zoom, setZoom] = useState(12);
+
+  const [places, setPlaces] = useState([]);
+  const [geometry, setGeometry] = useState([]);
+
+  const units = 'miles';
+
+  async function queryGeopoly(searchedLng, searchedLat) {
+    const db = new Database(process.env.REACT_APP_CONNECTION_STRING);
+
+    const db_name = 'geopoly-demo';
+
+    const radius = 0.05;
+    const sides = 50;
+
+    const polygonCoords =
+      await db.sql`USE DATABASE ${db_name}; INSERT INTO polygons(_shape) VALUES(geopoly_regular(${searchedLng}, ${searchedLat}, ${radius}, ${sides})) RETURNING geopoly_json(_shape);`;
+
+    const attractionsInPolygon =
+      await db.sql`USE DATABASE ${db_name}; SELECT name, coordinates FROM attractions WHERE geopoly_contains_point(${polygonCoords[0]['geopoly_json(_shape)']}, lng, lat);`;
+
+    db.close();
+
+    const namedAttractions = attractionsInPolygon.filter(
+      (attraction) => attraction.name !== null
+    );
+
+    const attractionFeatures = namedAttractions.map((attraction, index) => {
+      const attractionCoordinates = JSON.parse(attraction['coordinates']);
+
+      const attractionFeature = {
+        type: 'Feature',
+        geometry: {
+          type: 'Point',
+          coordinates: attractionCoordinates,
+        },
+        properties: {
+          id: index,
+          title: attraction['name'],
+          distance: distance(
+            point([searchedLng, searchedLat]),
+            point(attractionCoordinates),
+            {
+              units,
+            }
+          ),
+        },
+      };
+
+      const marker = document.createElement('div');
+      marker.key = `marker-${attractionFeature.properties.id}`;
+      marker.id = `marker-${attractionFeature.properties.id}`;
+      marker.className = 'marker';
+
+      marker.addEventListener('click', (e) => {
+        handleClick(attractionFeature);
+      });
+
+      new mapboxgl.Marker(marker)
+        .setLngLat(attractionCoordinates)
+        .addTo(mapRef.current);
+
+      return attractionFeature;
+    });
+
+    attractionFeatures.sort((a, b) => {
+      if (a.properties.distance > b.properties.distance) {
+        return 1;
+      }
+      if (a.properties.distance < b.properties.distance) {
+        return -1;
+      }
+      return 0;
+    });
+
+    setPlaces(attractionFeatures);
+
+    if (attractionFeatures[0]) {
+      const bbox = getBbox(attractionFeatures, searchedLng, searchedLat);
+      mapRef.current.fitBounds(bbox, {
+        padding: 100,
+      });
+
+      new mapboxgl.Popup({ closeOnClick: false })
+        .setLngLat(attractionFeatures[0].geometry.coordinates)
+        .setHTML(
+          `<h3>${
+            attractionFeatures[0].properties.title
+          }</h3><h4>${attractionFeatures[0].properties.distance.toFixed(
+            2
+          )} ${units} away</h4>`
+        )
+        .addTo(mapRef.current);
+    }
+
+    setGeometry([
+      {
+        type: 'Feature',
+        geometry: {
+          type: 'Polygon',
+          coordinates: [JSON.parse(polygonCoords[0]['geopoly_json(_shape)'])],
+        },
+      },
+      ...attractionFeatures,
+    ]);
+  }
+
+  function drawFeatureCollection() {
+    const sourceId = 'newyork';
+
+    if (!mapRef.current.getSource(sourceId)) {
+      mapRef.current.addSource(sourceId, {
+        type: 'geojson',
+        data: {
+          type: 'FeatureCollection',
+          features: geometry,
+        },
+      });
+
+      mapRef.current.addLayer({
+        id: 'polygon',
+        type: 'fill',
+        source: sourceId,
+        paint: {
+          'fill-color': '#888888',
+          'fill-opacity': 0.4,
+        },
+        filter: ['==', '$type', 'Polygon'],
+      });
+
+      mapRef.current.addLayer({
+        id: 'outline',
+        type: 'line',
+        source: sourceId,
+        layout: {},
+        paint: {
+          'line-color': '#000',
+          'line-width': 1,
+        },
+      });
+    } else {
+      mapRef.current.getSource(sourceId).setData({
+        type: 'FeatureCollection',
+        features: geometry,
+      });
+    }
+  }
+
+  function handleClick(feature) {
+    const center = feature.geometry.coordinates;
+    const { id, title, distance } = feature.properties;
+
+    mapRef.current.flyTo({
+      center,
+      zoom: 15,
+    });
+
+    const popUps = document.getElementsByClassName('mapboxgl-popup');
+    if (popUps[0]) {
+      popUps[0].remove();
+    }
+
+    new mapboxgl.Popup({ closeOnClick: false })
+      .setLngLat(center)
+      .setHTML(`<h3>${title}</h3><h4>${distance.toFixed(2)} ${units} away</h4>`)
+      .addTo(mapRef.current);
+
+    const activeItem = document.getElementsByClassName('active');
+    if (activeItem[0]) {
+      activeItem[0].classList.remove('active');
+    }
+
+    const listing = document.getElementById(`listing-${id}`);
+    listing.classList.add('active');
+  }
+
+  useEffect(() => {
+    mapRef.current = new mapboxgl.Map({
+      container: mapContainerRef.current,
+      style: 'mapbox://styles/mapbox/streets-v12',
+      center: [lng, lat],
+      zoom,
+    });
+
+    const geocoder = new MapboxGeocoder({
+      accessToken: mapboxgl.accessToken,
+      mapboxgl,
+      zoom: 12,
+    });
+
+    const fullscreenCtrl = new mapboxgl.FullscreenControl({
+      container: mapContainerRef.current,
+    });
+
+    const geolocateCtrl = new mapboxgl.GeolocateControl({
+      fitBoundsOptions: {
+        maxZoom: 12,
+      },
+      positionOptions: {
+        enableHighAccuracy: true,
+      },
+      trackUserLocation: true,
+    });
+
+    mapRef.current.addControl(geocoder);
+    mapRef.current.addControl(fullscreenCtrl);
+    mapRef.current.addControl(geolocateCtrl);
+
+    function updateCoordinates() {
+      const { lng, lat } = mapRef.current.getCenter();
+      setLng(lng.toFixed(4));
+      setLat(lat.toFixed(4));
+      setZoom(mapRef.current.getZoom().toFixed(2));
+    }
+
+    mapRef.current.on('move', updateCoordinates);
+
+    geocoder.on('result', (e) => {
+      const existingMarkers = document.getElementsByClassName('marker');
+      while (existingMarkers[0]) {
+        existingMarkers[0].remove();
+      }
+
+      const popUps = document.getElementsByClassName('mapboxgl-popup');
+      while (popUps[0]) {
+        popUps[0].remove();
+      }
+
+      const [lng, lat] = e.result.geometry.coordinates;
+      queryGeopoly(lng, lat);
+    });
+
+    return () => {
+      mapRef.current.removeControl(geocoder);
+      mapRef.current.removeControl(fullscreenCtrl);
+      mapRef.current.removeControl(geolocateCtrl);
+      mapRef.current.off('move', updateCoordinates);
+      mapRef.current.remove();
+    };
+  }, []); // eslint-disable-line react-hooks/exhaustive-deps
+
+  useEffect(() => {
+    if (geometry.length !== 0) {
+      drawFeatureCollection();
+    }
+  }, [geometry]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  return (
+    <>
+      <div className="sidebar">
+        <div className="legend">
+          <p>Center Lat: {lat}</p>
+          <p>Center Long: {lng}</p>
+          <p>Current Zoom: {zoom}</p>
+        </div>
+        <div className="heading">
+          <h2>Attractions Nearby:</h2>
+        </div>
+
+        <div className="listings">
+          {places.map((place, index) => (
+            <div
+              key={index}
+              id={`listing-${place.properties.id}`}
+              className={`item ${index === 0 && 'active'}`}
+            >
+              <a href="#" className="title" onClick={() => handleClick(place)}>
+                {place.properties.title}
+              </a>
+              <div>
+                {place.properties.distance.toFixed(2)} {units} away
+              </div>
+            </div>
+          ))}
+        </div>
+      </div>
+      <div ref={mapContainerRef} className="map-container" />
+    </>
+  );
+}
+
+export default App;
+```
+
+  - To understand how the app works, let's break down this monster component: 
+
+7. **Create the last helper function**
+
+  - Create `src/helpers/getBbox.js`. Copy and paste in the following code:
+
+```js
+export function getBbox(sortedEvents, locationLng, locationLat) {
+  const lons = [
+    sortedEvents[0].geometry.coordinates[0],
+    locationLng,
+  ];
+  const lats = [
+    sortedEvents[0].geometry.coordinates[1],
+    locationLat,
+  ];
+  const sortedLons = lons.sort((a, b) => {
+    if (a > b) {
+      return 1;
+    }
+    if (a.distance < b.distance) {
+      return -1;
+    }
+    return 0;
+  });
+  const sortedLats = lats.sort((a, b) => {
+    if (a > b) {
+      return 1;
+    }
+    if (a.distance < b.distance) {
+      return -1;
+    }
+    return 0;
+  });
+  return [
+    [sortedLons[0], sortedLats[0]],
+    [sortedLons[1], sortedLats[1]],
+  ];
+}
+```
+
+8. **Run your app!**
+
+  - Replace your `package.json` code with the following, which includes all dependencies needed to run the app:
+
+```json
+{
+  "name": "geopoly-demo",
+  "version": "1.0.0",
+  "private": true,
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "start": "react-scripts start",
+    "build": "react-scripts build",
+    "create-tables": "node src/helpers/createDatabase.js"
+  },
+  "eslintConfig": {
+    "extends": [
+      "react-app"
+    ]
+  },
+  "browserslist": [
+    "defaults",
+    "not ie 11"
+  ],
+  "author": "",
+  "license": "ISC",
+  "type": "module",
+  "dependencies": {
+    "@mapbox/mapbox-gl-geocoder": "^5.0.2",
+    "@sqlitecloud/drivers": "^1.0.193",
+    "@turf/turf": "^7.0.0",
+    "mapbox-gl": "^3.5.2",
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1",
+    "react-scripts": "^5.0.1"
+  },
+  "devDependencies": {
+    "@babel/plugin-proposal-private-property-in-object": "^7.21.11",
+    "dotenv": "^16.4.5"
+  }
+}
+```  
+
+  - From your project dir, install the dependencies and start your local dev server.
+
+```bash
+npm i
+npm start
+```
+
+  - Visit `http://localhost:3000/` (adjust the port as-needed) in your browser to view the application.
+
+9. **Find attractions near you!**
+
+  - USE CASE 1: You used the NYC geodata fetched with the provided Overpass query.
+
+    - On app load, the map is centered on Central Park, NYC.
+
+    - In the geocoder (i.e. search input) at the top right of the map, enter "Empire" and select the "Empire State Building" search result.
+
+    - When you select a geocoder result:
+      - a polygon is generated by Geopoly, added to your `polygons` table, and displayed on the map.
+
+      - all attractions from your `attractions` table calculated to be inside the polygon area (outline inclusive) are listed in the left sidebar AND marked on the map. NOTE: the sidebar upsorts attractions nearest the searched location.
+
+    - As an aside: To see the inserted polygon data, in your SQLite Cloud account dashboard's left nav, click Console. Copy, paste in, and run the following query:
+
+```sql
+SELECT rowid, geopoly_json(_shape) FROM polygons;
+```
+      - `geopoly_json()` parses the Array(buffer) data into an array of coordinate pairs representing the polygon vertices. The array should contain (1 + # of polygon sides) coordinate pairs.
+
+    - The map will zoom in to the closest attraction to your searched location, in this case the "Empire State Building". However, you can click any attraction listing or marker to zoom in to that attraction on the map.
+
+  - USE CASE 2: If you used a custom Overpass query to fetch geodata near your location, then after the map loads, click on the map's GeolocateControl and allow the browser to use your IP to locate you on the map. The map will fly to and center on your location. This way you will get more relevant results from the geocoder search and your polygon will contain (more) attractions.

--- a/sqlite-cloud/tutorial-geopoly.mdx
+++ b/sqlite-cloud/tutorial-geopoly.mdx
@@ -1,26 +1,20 @@
 ---
-title: SQLite Spotlight - Geopoly Extension
+title: Using SQLite Extensions - Geopoly
 description: Build a local attractions finder app using SQLite Cloud, SQLite's built-in Geopoly extension, Mapbox, and React.
 category: getting-started
 status: publish
 slug: tutorial-geopoly
 ---
 
-This tutorial demonstrates how to build a local attractions finder app. The app uses:
-- GeoJSON data
-- a SQLite Cloud database
-- Mapbox JavaScript Graphics Library (GL JS)
-  - user has to create an account/ get a token!
-- React
-- SQLite's built-in Geopoly extension
+In this tutorial you will build a local attractions finder map-plication using GeoJSON data, a SQLite Cloud database, [Mapbox GL JS](https://docs.mapbox.com/mapbox-gl-js/guides) (JavaScript Graphics Library), React, and SQLite's built-in [Geopoly extension](https://devdocs.io/sqlite/geopoly).
 
-Time to complete: ~15-20 mins.
+**Time to complete: 15-20 mins.**
 
-If you get stuck in the tutorial or prefer to play with the finished product, check out [the example app on GitHub](https://github.com/sqlitecloud/examples/tree/main/geopoly).
+If you get stuck in the tutorial or prefer to play with the finished product, check out [the example app on GitHub](https://github.com/sqlitecloud/examples/tree/main/geopoly-demo).
 
 ---
 
-1. **Initialize your app**
+**1. Initialize your app**
   - Create a new directory `sqlc-geopoly-demo`. From this directory, bootstrap a Node.js project.
 
 ```bash
@@ -29,11 +23,11 @@ cd sqlc-geopoly-demo
 npm init -y
 ```
 
-2. **Curate your GeoJSON data**
+**2. Curate your GeoJSON data**
 
-  - We will leverage the [Overpass API](https://wiki.openstreetmap.org/wiki/Overpass_API) (an open-source, read-only API for fetching OpenStreetMap data) to query NYC attractions.
+  - We will leverage the [Overpass API](https://wiki.openstreetmap.org/wiki/Overpass_API) (an open-source, read-only API for fetching OpenStreetMap data) to query NY attractions.
 
-  - Visit [Overpass Turbo](https://overpass-turbo.eu/), the Overpass GUI. Copy and paste in the below query which:
+  - Visit [Overpass Turbo](https://overpass-turbo.eu/), the Overpass GUI. Copy and paste in the below query, which:
     - defines New York as the area of interest;
     - fetches nodes in the specified area that are tagged with the keys `amenity`, `historic`, `tourism`, `leisure`, etc.; and
     - outputs the data.
@@ -67,9 +61,7 @@ out skel qt;
 
   - Click Export. Under Data, copy the GeoJSON.
 
-  - Use [a JSON formatter](https://jsonformatter.org/) to correctly format the copied JSON.
-
-  - Back in your project dir, create `data/geodata.json`. Paste the formatted GeoJSON into the file. It should look as follows:
+  - Back in your project dir, create `data/geodata.json`. Paste the formatted GeoJSON into the file. It should look similar to the following:
 
 ```json
 {
@@ -110,34 +102,35 @@ out skel qt;
   ]
 }
 ```
+  - For this tutorial, we'll use the NY geodata. Once you have the app up-and-running, you can run your own Overpass queries to customize the geodata per your needs. See **Additional Guidance on Overpass** at the end of this tutorial.
 
-  - To pull other types of attractions or any other kind of location data in an area of interest to you, refer to [OpenStreetMap's Map features documentation](https://wiki.openstreetmap.org/wiki/Map_features) and modify the above query's area and key-value pairs.
-
-  - NOTE: The app currently only works with Point features (represented in the [doc's](https://wiki.openstreetmap.org/wiki/Map_features) Element column by an icon containing a dot), so be sure to query only:
-    - nodes, and
-    - the key-value pairs that can return Point data. For example, don't use most values available for the Boundary key.
-
-  - To implement more complex or granular Point queries, refer to the [Overpass QL documentation](https://wiki.openstreetmap.org/wiki/Overpass_API/Overpass_QL).
-
-3. **Create a new / empty SQLite Cloud database**
+**3. Create a new SQLite Cloud database**
 
   - If you haven't already, [sign up for a SQLite Cloud account](https://sqlitecloud.io/register) and create a new project.
 
-  - In your account dashboard's left nav, click Databases, then the Create Database button. To minimize code changes, name your new database `geopoly-demo`.
+  - In your account dashboard's left nav, click Databases, then Create Database. Name your new database `geopoly-demo`.
 
-4. **Set an environment variable**
+**4. Create a Mapbox account**
 
-  - In your project dir, create a `.env` file with a new environment variable `REACT_APP_CONNECTION_STRING`. Copy your connection string from your account dashboard and assign it to the variable.
-    - CONTEXT: This app will use `react-scripts`, which leverages Create React App under-the-hood. Create React App offers built-in support for env vars. You will not need to manually configure `webpack` or another bundler, but all vars must be prefixed with `REACT_APP_`.
+  - [Sign up](https://account.mapbox.com/auth/signup/) for an Individual Mapbox account. (We'll stay on the free tier.)
 
-  - Install the SQLite Cloud JS SDK and dotenv package as dependencies:
+**5. Set your environment variables**
+
+  - In your project dir, create a `.env` file.
+    - This app will use `react-scripts`, which leverages Create React App under-the-hood. Create React App offers built-in support for env vars. You will not need to manually configure `webpack` or another bundler, but all vars will need to be prefixed with `REACT_APP_`.
+
+  - Add 2 env vars to the file:
+    - `REACT_APP_CONNECTION_STRING`. Copy and paste your connection string from your SQLite Cloud account dashboard.
+    - `REACT_APP_MAPBOX_TOKEN`. In your Mapbox account dashboard's nav, click Tokens. Copy and paste your default public token.
+
+  - Install the SQLite Cloud JS SDK and `dotenv` package as dependencies:
 
 ```bash
 npm i @sqlitecloud/drivers
 npm i -D dotenv
 ```
 
-5. **Create your DB tables**
+**6. Create your database tables**
 
   - In your project dir, create `src/helpers/createDatabase.js`. Copy and paste in the following code:
 
@@ -175,32 +168,31 @@ createDatabase();
 ```
 
   - The `createDatabase` function:
-    - connects to your `geopoly-demo` database
-    - creates a virtual Geopoly table with 2 columns: `rowid` (which does not display in SQLite Cloud's Console but can be queried) and `_shape`
-    - creates an `attractions` table with 5 columns: `id`, `name`, `lng`, `lat`, and `coordinates`
-    - populates the `attractions` table using the GeoJSON FeatureCollection you generated earlier
-    - closes the database connection.
+    - connects to your `geopoly-demo` database;
+    - creates a virtual `polygons` table with 2 columns: `rowid` and `_shape`;
+    - creates an `attractions` table with 5 columns: `id`, `name`, `lng`, `lat`, and `coordinates`; and
+    - populates the `attractions` table using the GeoJSON FeatureCollection in `geodata.json`.
   
-  - Add the following script to your `package.json`:
+  - Add the following to your `package.json`:
 
 ```json
 "scripts": {
   "create-tables": "node src/helpers/createDatabase.js"
-}
+},
+"type": "module",
 ```
 
   - Run `npm run create-tables`.
 
-    - The time it will take for the command to finish creating tables and inserting the geodata will depend on the size of your FeatureCollection. The example Overpass query provided above returns ~2000 NYC Point features and takes a couple of minutes.
+    - The time it will take for the command to finish creating the tables and inserting the geodata will depend on the size of your FeatureCollection. The NY Overpass query returns ~2000 Point features, so row insertion takes a couple of minutes.
 
-    - As an aside: To see the inserted attractions geodata, in your SQLite Cloud account dashboard's left nav, click Console. Copy, paste in, and run the following query:
+    - To see the inserted NY attractions geodata, in your SQLite Cloud account dashboard's left nav, click Console. In the database dropdown, select `geopoly-demo`. Copy, paste in, and run the following query:
 
 ```sql
 SELECT * FROM attractions ORDER BY id DESC;
 ```
-      - If you used the provided Overpass query, ~2000 rows are added.
 
-6. **Setup the frontend**
+**7. Set up the frontend**
 
   - In your project dir, create `public/index.html`. Copy and paste in the following code:
 
@@ -214,7 +206,7 @@ SELECT * FROM attractions ORDER BY id DESC;
       name="description"
       content="Create a React web app that uses Mapbox GL JS to render a map"
     />
-    <title>Local Attraction Finder</title>
+    <title>Local Attractions Finder</title>
   </head>
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>
@@ -223,7 +215,7 @@ SELECT * FROM attractions ORDER BY id DESC;
 </html>
 ```
 
-  - In the `src` dir, add 3 files: `index.css` (for app styling), `index.js` (the app entrypoint file), and `App.js` (the one-and-only component). Copy and paste in the following code for each file:
+  - In the `src` dir, add 3 files: `index.css` (for app styling), `index.js` (the app entrypoint file), and `App.js` (the app's sole component). Copy and paste in the following code for each file:
 
 `index.css`
 ```css
@@ -340,8 +332,8 @@ body {
 .marker {
   border: none;
   cursor: pointer;
-  width: 26px;
-  height: 34px;
+  width: 32px;
+  height: 40px;
   background-image: url('https://docs.mapbox.com/mapbox-gl-js/assets/custom_marker.png');
 }
 
@@ -360,7 +352,7 @@ body {
 }
 ```
 
-  - NOTE: To simplify this tutorial, `.marker.background-image` uses a custom Mapbox marker for the map pins marking attractions. [The example app on GitHub](https://github.com/sqlitecloud/examples/tree/main/geopoly) uses a custom marker image included in the repo's `images` dir (excluded here).
+  - NOTE: To simplify this tutorial, `.marker.background-image` uses a custom Mapbox marker for the pins marking attractions on the map. [The example app on GitHub](https://github.com/sqlitecloud/examples/tree/main/geopoly) uses a custom marker image included in the repo's `images` dir (excluded here).
 
 `index.js`
 ```js
@@ -389,8 +381,7 @@ import { point, distance } from '@turf/turf';
 import { Database } from '@sqlitecloud/drivers';
 import { getBbox } from './helpers/getBbox.js';
 
-mapboxgl.accessToken =
-  'pk.eyJ1IjoidW5hdGFyYWphbiIsImEiOiJjbDFpcW82MGYxeDE1M2RwNjU4MmZ1YndsIn0.HyxwEtZz-pQ_7R6e48l0-g';
+mapboxgl.accessToken = process.env.REACT_APP_MAPBOX_TOKEN;
 
 function App() {
   const mapContainerRef = useRef();
@@ -682,9 +673,29 @@ function App() {
 export default App;
 ```
 
-  - To understand how the app works, let's break down this monster component: 
+  - To understand how the app works, let's break down this monster component's core functionality: 
 
-7. **Create the last helper function**
+    - The first `useEffect`:
+      - creates, styles, and centers the map;
+      - applies 3 controls to the top right of the map: a geocoder (i.e. address search input), an icon to toggle the map to fullscreen mode, and an icon to locate the app user on the map;
+      - sets an event listener to track the map center coordinates and zoom level, all displayed on the top left of the app; and
+      - sets an event listener on the geocoder to call the `queryGeopoly` function when the user clicks a geocoder result.
+
+    - The `queryGeopoly` function:
+      - connects to your `geopoly-demo` database;
+      - uses the `geopoly_regular` function to generate a polygon and adds it to the `polygons` table (set a positive `radius` and up to 1000 `sides`);
+      - returns all named attractions in the polygon area;
+      - uses Turf.js to calculate the distance between the searched location and each attraction (set `units` to be miles or kilometers);
+      - applies clickable markers for all attractions on the map;
+      - upsorts attractions nearest the user's searched location;
+      - uses the `getBbox` helper function (defined in the next step) to zoom the map to the attraction nearest the searched location; and
+      - updates the `geometry` state to hold the returned Polygon and attraction Point features.
+
+    - The second `useEffect`:
+      - is triggered by the `geometry` state update; and
+      - calls the `drawFeatureCollection` function to draw the returned Polygon, its outline, and attraction Points on the map. 
+
+**8. Create a helper function**
 
   - Create `src/helpers/getBbox.js`. Copy and paste in the following code:
 
@@ -723,13 +734,17 @@ export function getBbox(sortedEvents, locationLng, locationLat) {
 }
 ```
 
-8. **Run your app!**
+  - The `getBbox` function:
+    - generates a bounding box, defined by a southwest coordinate pair and northeast coordinate pair; and
+    - is used in `queryGeopoly` to fit/ zoom the map view to a user's searched location and its nearest attraction.
+
+**9. Run your app!**
 
   - Replace your `package.json` code with the following, which includes all dependencies needed to run the app:
 
 ```json
 {
-  "name": "geopoly-demo",
+  "name": "sqlc-geopoly-demo",
   "version": "1.0.0",
   "private": true,
   "description": "",
@@ -774,28 +789,46 @@ npm i
 npm start
 ```
 
-  - Visit `http://localhost:3000/` (adjust the port as-needed) in your browser to view the application.
+  - Visit `http://localhost:3000/` (adjust the port as-needed) in your browser to view the app.
 
-9. **Find attractions near you!**
+**10. Find attractions!**
 
-  - USE CASE 1: You used the NYC geodata fetched with the provided Overpass query.
+  - On app load, the map is centered on Central Park, NY.
 
-    - On app load, the map is centered on Central Park, NYC.
+  - In the geocoder (i.e. search input) at the top right of the map, enter "Empire" and click on the "Empire State Building" result. You can also search coordinates (see [reverse geocoding](https://docs.mapbox.com/api/search/geocoding/)).
 
-    - In the geocoder (i.e. search input) at the top right of the map, enter "Empire" and select the "Empire State Building" search result.
+  - When you select a geocoder result:
+    - a polygon is generated by Geopoly, added to your `polygons` table, and displayed on the map; and
 
-    - When you select a geocoder result:
-      - a polygon is generated by Geopoly, added to your `polygons` table, and displayed on the map.
+    - all attractions in your `attractions` table inside the polygon area are listed in the left sidebar AND marked on the map. NOTE: the sidebar upsorts attractions nearest your searched location, in this case the "Empire State Building".
 
-      - all attractions from your `attractions` table calculated to be inside the polygon area (outline inclusive) are listed in the left sidebar AND marked on the map. NOTE: the sidebar upsorts attractions nearest the searched location.
+  - To see the inserted polygon data, in your SQLite Cloud account dashboard's left nav, click Console. In the database dropdown, select `geopoly-demo`. Copy, paste in, and run the following query.
 
-    - As an aside: To see the inserted polygon data, in your SQLite Cloud account dashboard's left nav, click Console. Copy, paste in, and run the following query:
+    - The `geopoly_json` function parses the `_shape` column's `[object ArrayBuffer]` data into an array of coordinate pairs representing the polygon's vertices: `[[-73.9355,40.7485],[-73.9359,40.7547], ...,[-73.9359,40.7422],[-73.9355,40.7485]]`. The array should contain (1 + # of polygon sides) coordinate pairs. The polygon is closed, so the first and last pairs both represent the same vertex.
 
 ```sql
 SELECT rowid, geopoly_json(_shape) FROM polygons;
 ```
-      - `geopoly_json()` parses the Array(buffer) data into an array of coordinate pairs representing the polygon vertices. The array should contain (1 + # of polygon sides) coordinate pairs.
 
-    - The map will zoom in to the closest attraction to your searched location, in this case the "Empire State Building". However, you can click any attraction listing or marker to zoom in to that attraction on the map.
+  - The map zooms in to the nearest attraction to your searched location and highlights its corresponding top listing in the sidebar.
+    
+    - You can click on any attraction listing or marker to fly/ zoom to and center on that attraction on the map.
 
-  - USE CASE 2: If you used a custom Overpass query to fetch geodata near your location, then after the map loads, click on the map's GeolocateControl and allow the browser to use your IP to locate you on the map. The map will fly to and center on your location. This way you will get more relevant results from the geocoder search and your polygon will contain (more) attractions.
+    - Turf.js calculates straight-line distances between your searched location and each attraction. Expect discrepancies between this app's calculated distances vs, say, Google or Apple Maps.
+
+And that’s it! You’ve successfully built a local attractions finder app that utilizes Geopoly to write geodata to and read from a SQLite Cloud database.
+
+### Additional Guidance on Overpass:
+  - To fetch other attractions or any other kind of location data in NY or another area of interest to you, refer to [OpenStreetMap's Map features documentation](https://wiki.openstreetmap.org/wiki/Map_features). As a starting point, modify the area or key-value pairs in the NY query.
+
+  - NOTE: The app works only with Point features (represented in the [Map features](https://wiki.openstreetmap.org/wiki/Map_features) tables' `Element` columns by an icon with a single dot). Be sure to query only nodes and the key-value pairs that can return Point data. For example, don't use most of the values available for the Boundary key.
+
+  - To implement more complex or granular Point queries, refer to the [Overpass QL documentation](https://wiki.openstreetmap.org/wiki/Overpass_API/Overpass_QL).
+
+  - If you run a custom Overpass query:
+    - Add to or replace the FeatureCollection in `geodata.json`.
+    - In your SQLite Cloud account dashboard's left nav, click Databases. In the `geopoly-demo` row, click the down chevron and then Delete Database.
+    - Create Database with the same name.
+    - From your project dir, run `npm run create-tables`. Your database tables will be re-created, and the `attractions` table will be populated with your updated geodata.
+  
+  - If you queried and stored attractions near your location, then after the app's initial load, click on the [GeolocateControl icon](https://docs.mapbox.com/mapbox-gl-js/example/locate-user/) at the top right of the map and allow the browser to quickly center the map on your location. Search away!

--- a/sqlite-cloud/tutorial-geopoly.mdx
+++ b/sqlite-cloud/tutorial-geopoly.mdx
@@ -140,15 +140,19 @@ import 'dotenv/config';
 import geodata from '../../data/geodata.json' assert { type: 'json' };
 
 async function createDatabase() {
+  // open a connection to your `geopoly-demo` database
   const db = new Database(process.env.REACT_APP_CONNECTION_STRING);
 
   const db_name = 'geopoly-demo';
   await db.sql`USE DATABASE ${db_name};`;
 
+  // create a table with 2 columns: `rowid` and `_shape`
   await db.sql`CREATE VIRTUAL TABLE polygons USING geopoly()`;
 
+  // create a table with 5 columns: `id`, `name`, `lng`, `lat`, and `coordinates`
   await db.sql`CREATE TABLE attractions (id INTEGER PRIMARY KEY AUTOINCREMENT, name TEXT, lng REAL NOT NULL, lat REAL NOT NULL, coordinates TEXT NOT NULL)`;
 
+  // populate the `attractions` table using the GeoJSON FeatureCollection in `geodata.json`
   for (const feature of geodata['features']) {
     const { name } = feature.properties;
     const { coordinates } = feature.geometry;
@@ -166,12 +170,6 @@ async function createDatabase() {
 
 createDatabase();
 ```
-
-  - The `createDatabase` function:
-    - connects to your `geopoly-demo` database;
-    - creates a virtual `polygons` table with 2 columns: `rowid` and `_shape`;
-    - creates an `attractions` table with 5 columns: `id`, `name`, `lng`, `lat`, and `coordinates`; and
-    - populates the `attractions` table using the GeoJSON FeatureCollection in `geodata.json`.
   
   - Add the following to your `package.json`:
 
@@ -397,21 +395,25 @@ function App() {
   const units = 'miles';
 
   async function queryGeopoly(searchedLng, searchedLat) {
+    // open a connection to your `geopoly-demo` database
     const db = new Database(process.env.REACT_APP_CONNECTION_STRING);
 
     const db_name = 'geopoly-demo';
 
-    const radius = 0.05;
-    const sides = 50;
+    const radius = 0.05; // must be a positive number
+    const sides = 50; // 3-1000
 
+    // generate a new polygon to be added to your `polygons` table
     const polygonCoords =
       await db.sql`USE DATABASE ${db_name}; INSERT INTO polygons(_shape) VALUES(geopoly_regular(${searchedLng}, ${searchedLat}, ${radius}, ${sides})) RETURNING geopoly_json(_shape);`;
 
+    // point-in-polygon query to get all attractions in the generated polygon's area
     const attractionsInPolygon =
       await db.sql`USE DATABASE ${db_name}; SELECT name, coordinates FROM attractions WHERE geopoly_contains_point(${polygonCoords[0]['geopoly_json(_shape)']}, lng, lat);`;
 
     db.close();
 
+    // remove unnamed attractions
     const namedAttractions = attractionsInPolygon.filter(
       (attraction) => attraction.name !== null
     );
@@ -428,16 +430,18 @@ function App() {
         properties: {
           id: index,
           title: attraction['name'],
+          // use Turf.js to calculate the distance between the searched location and the current attraction
           distance: distance(
             point([searchedLng, searchedLat]),
             point(attractionCoordinates),
             {
-              units,
+              units, // either miles or kilometers
             }
           ),
         },
       };
 
+      // apply clickable markers for all attractions
       const marker = document.createElement('div');
       marker.key = `marker-${attractionFeature.properties.id}`;
       marker.id = `marker-${attractionFeature.properties.id}`;
@@ -454,6 +458,7 @@ function App() {
       return attractionFeature;
     });
 
+    // upsort attractions nearest the user's searched location
     attractionFeatures.sort((a, b) => {
       if (a.properties.distance > b.properties.distance) {
         return 1;
@@ -466,6 +471,7 @@ function App() {
 
     setPlaces(attractionFeatures);
 
+    // use a helper function (defined in the next step) to fit/ zoom the map view to the searched location and its nearest attraction
     if (attractionFeatures[0]) {
       const bbox = getBbox(attractionFeatures, searchedLng, searchedLat);
       mapRef.current.fitBounds(bbox, {
@@ -484,6 +490,7 @@ function App() {
         .addTo(mapRef.current);
     }
 
+    // update the `geometry` state to hold the returned Polygon and attraction Point features
     setGeometry([
       {
         type: 'Feature',
@@ -566,6 +573,7 @@ function App() {
   }
 
   useEffect(() => {
+    // create, style, and center the map
     mapRef.current = new mapboxgl.Map({
       container: mapContainerRef.current,
       style: 'mapbox://styles/mapbox/streets-v12',
@@ -573,16 +581,20 @@ function App() {
       zoom,
     });
 
+    // apply 3 controls to the top right of the map
+    // an address search input
     const geocoder = new MapboxGeocoder({
       accessToken: mapboxgl.accessToken,
       mapboxgl,
       zoom: 12,
     });
 
+    // toggle fullscreen mode
     const fullscreenCtrl = new mapboxgl.FullscreenControl({
       container: mapContainerRef.current,
     });
 
+    // locate the user on the map
     const geolocateCtrl = new mapboxgl.GeolocateControl({
       fitBoundsOptions: {
         maxZoom: 12,
@@ -597,6 +609,7 @@ function App() {
     mapRef.current.addControl(fullscreenCtrl);
     mapRef.current.addControl(geolocateCtrl);
 
+    // track the map center coordinates and zoom level (displayed on the top left of the app)
     function updateCoordinates() {
       const { lng, lat } = mapRef.current.getCenter();
       setLng(lng.toFixed(4));
@@ -606,6 +619,7 @@ function App() {
 
     mapRef.current.on('move', updateCoordinates);
 
+    // call the `queryGeopoly` function when the user clicks a geocoder result
     geocoder.on('result', (e) => {
       const existingMarkers = document.getElementsByClassName('marker');
       while (existingMarkers[0]) {
@@ -630,8 +644,10 @@ function App() {
     };
   }, []); // eslint-disable-line react-hooks/exhaustive-deps
 
+  // triggered by a `geometry` state update
   useEffect(() => {
     if (geometry.length !== 0) {
+      // draw the returned Polygon, its outline, and attraction Points on the map
       drawFeatureCollection();
     }
   }, [geometry]); // eslint-disable-line react-hooks/exhaustive-deps
@@ -673,28 +689,6 @@ function App() {
 export default App;
 ```
 
-  - To understand how the app works, let's break down this monster component's core functionality: 
-
-    - The first `useEffect`:
-      - creates, styles, and centers the map;
-      - applies 3 controls to the top right of the map: a geocoder (i.e. address search input), an icon to toggle the map to fullscreen mode, and an icon to locate the app user on the map;
-      - sets an event listener to track the map center coordinates and zoom level, all displayed on the top left of the app; and
-      - sets an event listener on the geocoder to call the `queryGeopoly` function when the user clicks a geocoder result.
-
-    - The `queryGeopoly` function:
-      - connects to your `geopoly-demo` database;
-      - uses the `geopoly_regular` function to generate a polygon and adds it to the `polygons` table (set a positive `radius` and up to 1000 `sides`);
-      - returns all named attractions in the polygon area;
-      - uses Turf.js to calculate the distance between the searched location and each attraction (set `units` to be miles or kilometers);
-      - applies clickable markers for all attractions on the map;
-      - upsorts attractions nearest the user's searched location;
-      - uses the `getBbox` helper function (defined in the next step) to zoom the map to the attraction nearest the searched location; and
-      - updates the `geometry` state to hold the returned Polygon and attraction Point features.
-
-    - The second `useEffect`:
-      - is triggered by the `geometry` state update; and
-      - calls the `drawFeatureCollection` function to draw the returned Polygon, its outline, and attraction Points on the map. 
-
 **8. Create a helper function**
 
   - Create `src/helpers/getBbox.js`. Copy and paste in the following code:
@@ -727,16 +721,14 @@ export function getBbox(sortedEvents, locationLng, locationLat) {
     }
     return 0;
   });
+
+  // return a bounding box, defined by a southwest coordinate pair and northeast coordinate pair
   return [
     [sortedLons[0], sortedLats[0]],
     [sortedLons[1], sortedLats[1]],
   ];
 }
 ```
-
-  - The `getBbox` function:
-    - generates a bounding box, defined by a southwest coordinate pair and northeast coordinate pair; and
-    - is used in `queryGeopoly` to fit/ zoom the map view to a user's searched location and its nearest attraction.
 
 **9. Run your app!**
 
@@ -814,11 +806,12 @@ SELECT rowid, geopoly_json(_shape) FROM polygons;
     
     - You can click on any attraction listing or marker to fly/ zoom to and center on that attraction on the map.
 
-    - Turf.js calculates straight-line distances between your searched location and each attraction. Expect discrepancies between this app's calculated distances vs, say, Google or Apple Maps.
+    - [Turf.js uses the Haversine formula](https://turfjs.org/docs/api/distance) to account for global curvature when calculating the distance between your searched location and each attraction. However, you should still expect discrepancies between this app's calculated distances vs, say, Google or Apple Maps.
 
 And that’s it! You’ve successfully built a local attractions finder app that utilizes Geopoly to write geodata to and read from a SQLite Cloud database.
 
 ### Additional Guidance on Overpass:
+
   - To fetch other attractions or any other kind of location data in NY or another area of interest to you, refer to [OpenStreetMap's Map features documentation](https://wiki.openstreetmap.org/wiki/Map_features). As a starting point, modify the area or key-value pairs in the NY query.
 
   - NOTE: The app works only with Point features (represented in the [Map features](https://wiki.openstreetmap.org/wiki/Map_features) tables' `Element` columns by an icon with a single dot). Be sure to query only nodes and the key-value pairs that can return Point data. For example, don't use most of the values available for the Boundary key.


### PR DESCRIPTION
# Overview / Task
- [ ] Bug
- [x] Feature

## Description
- Created a tutorial to build the example app demo'ing SQLite's Geopoly extension.
- Added links in Documentation left nav for users to view the tutorial.

## Feature Validation / Bug Reproduction Steps
1. From the `website` repo, `npm run dev-docs-website`.
2. Load the localhost link in browser: `http://localhost:4321/docs/tutorial-geopoly`.

## Screenshots & Videos
<img width="1438" alt="Screenshot 2024-08-07 at 7 27 53 PM" src="https://github.com/user-attachments/assets/b49a6d6b-9800-407f-9093-e0b9e3a9c15d">
<img width="594" alt="Screenshot 2024-08-07 at 7 28 28 PM" src="https://github.com/user-attachments/assets/00100934-adf1-43ac-b317-b6d71b23a797">
<img width="577" alt="Screenshot 2024-08-07 at 7 28 17 PM" src="https://github.com/user-attachments/assets/8ee52193-8098-4570-8bab-87a8a430cb6a">
<img width="1439" alt="Screenshot 2024-08-07 at 7 22 04 PM" src="https://github.com/user-attachments/assets/be81b9df-f884-42ed-bed8-eefe9c1c91f8">