### PR TITLE
React Native QS app not working on iOS

### DIFF
--- a/sqlite-cloud/quick-start-react-native.mdx
+++ b/sqlite-cloud/quick-start-react-native.mdx
@@ -46,9 +46,10 @@ export default function App() {
 
   useEffect(() => {
     async function getAlbums() {
-      const db = new Database(
-        '<your-connection-string>'
-      );
+      const db = new Database({
+        connectionstring: '<your-connection-string>',
+        usewebsocket: true,
+      });
 
       const result =
         await db.sql`USE DATABASE chinook.sqlite; SELECT albums.AlbumId as id, albums.Title as title, artists.name as artist FROM albums INNER JOIN artists WHERE artists.ArtistId = albums.ArtistId LIMIT 20;`;


### PR DESCRIPTION
# Overview / Task
- [x] Bug Fix
- [ ] Feature

## Description
Updating per 2 Slack threads:
- [thread](https://sqlitecloudinc.slack.com/archives/C02J63QKXQC/p1723150675513229) indicating `TypeError: tls.connect is not a function (it is undefined)` on iOS simulator when trying to connect to the SQLite Cloud database. The value of tls in the @sqlitecloud/drivers/lib/drivers/connection-tls.js file is {"default": {}}.
- [thread](https://sqlitecloudinc.slack.com/archives/C02J63QKXQC/p1723239534961089?thread_ts=1723150810.733459&cid=C02J63QKXQC) with the temporary fix.

## Feature Validation / Bug Reproduction Steps
Follow QS on iOS. At `Step 4. Query data`, note that the DB instance is passed an options object containing the connection string and allowing TLS connection over web socket, NOT just the connection string.

```tsx
const db = new Database({
  connectionstring: '<your-connection-string>',
  usewebsocket: true,
});
```

## Screenshots & Videos
[Video](https://www.loom.com/share/e66f807e817447f6bd2505fa943d1288?sid=db097aea-4aed-4738-9eaf-b5e1c799ab81) on Apple M1 Pro laptop.